### PR TITLE
Fix hack menu squarespace

### DIFF
--- a/src/utils/hack-squarespace-menu.ts
+++ b/src/utils/hack-squarespace-menu.ts
@@ -227,7 +227,7 @@ function hackMobileMenu(userIsLoggedIn: boolean, crankMenuUrls: MenuUrls) {
       const subMenuProfileLink = document.createElement('a')
       subMenuProfileLink.className = mobileClassName
       subMenuProfileLink.href = crankMenuUrls.profileUrl
-      subMenuProfileLink.innerText = 'My Profile'
+      subMenuProfileLink.innerText = 'Login'
       myAccountDiv.appendChild(subMenuProfileLink)
     }
   }


### PR DESCRIPTION
update mobile menu link text from 'My Profile' to 'Login'