### PR TITLE
Apple pay integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
       "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.13.9.tgz",
       "integrity": "sha512-RStSzQfL1XwL6/NWd7W8avhGQYTgPCtJ+qHkkTTSj9Upp3VVm6Oppv81YWdXG1FgEpDPW4hvCrTUELdcC4inCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/caches": "^1.0.0",
@@ -324,6 +325,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.0.tgz",
       "integrity": "sha512-PuxUbxcW6ZYe656yL3EAhpy7qXKq0DmYsrJLpbB8XrsCP9Nm+XCg9XFMb5vIDliPD7+U/+M+QJlH17XOcB7eXA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
@@ -1184,6 +1186,40 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+      "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+      "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
@@ -1290,6 +1326,7 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.7.2.tgz",
       "integrity": "sha512-yxtOBWDrdi5DD5o1pmVdq3WMCvnobT0LU6R8RyyVXPvFRd2o79/0NCuQoCjNTeZz9EzA9xS3JxNWfv54RIHFEA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.7.2"
       },
@@ -3473,7 +3510,8 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
       "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -3633,6 +3671,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -4416,6 +4455,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4558,6 +4598,7 @@
       "version": "3.44.0",
       "resolved": "https://registry.npmjs.org/apexcharts/-/apexcharts-3.44.0.tgz",
       "integrity": "sha512-u7Xzrbcxc2yWznN78Jh5NMCYVAsWDfBjRl5ea++rVzFAqjU2hLz4RgKIFwYOBDRQtW1e/Qz8azJTqIJ1+Vu9Qg==",
+      "peer": true,
       "dependencies": {
         "@yr/monotone-cubic-spline": "^1.0.3",
         "svg.draggable.js": "^2.2.2",
@@ -4947,6 +4988,7 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -5449,6 +5491,7 @@
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
       "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -5779,6 +5822,7 @@
       "version": "2.30.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
       "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       },
@@ -6119,6 +6163,7 @@
       "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1"
       },
@@ -6293,6 +6338,312 @@
         "esbuild-windows-arm64": "0.15.18"
       }
     },
+    "node_modules/esbuild-android-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+      "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-android-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+      "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+      "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-darwin-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+      "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+      "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-freebsd-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+      "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-32": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+      "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+      "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+      "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+      "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-mips64le": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+      "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-ppc64le": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+      "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-riscv64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+      "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-linux-s390x": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+      "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-netbsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+      "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-openbsd-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+      "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-sunos-64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+      "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-32": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+      "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/esbuild-windows-64": {
       "version": "0.15.18",
       "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
@@ -6301,6 +6652,23 @@
         "x64"
       ],
       "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/esbuild-windows-arm64": {
+      "version": "0.15.18",
+      "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+      "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -6419,6 +6787,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6550,6 +6919,7 @@
       "integrity": "sha512-174lJKuNsuDIlLpjeXc5E2Tss8P44uIimAfGD0b90k0NoirJqpG7stLuU9Vp/9ioTOrQdWVREc4mRd1BD+CvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
         "globals": "^13.24.0",
@@ -7524,6 +7894,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
       "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -7633,6 +8004,7 @@
       "integrity": "sha512-umt4f5NnMK46ChM2coO36PTFhHouBrK9stWWBczERguwYrGnPNxJ9dimU6IyOBfOkC6Izhkg4H8+F51W/8CYDg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10071,6 +10443,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -10241,6 +10614,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -11348,6 +11722,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11490,6 +11865,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11716,6 +12092,7 @@
       "integrity": "sha512-K/jGKL/PgbIgKCiJo5QbASQhFiV02X9Jh+Qq0AKCRCRKZtOTVi4t6wh75FDpGf2N9rYOnzH87OEFQNaFy6pdxQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.15.9",
         "postcss": "^8.4.18",
@@ -11817,6 +12194,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.18.tgz",
       "integrity": "sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.18",
         "@vue/compiler-sfc": "3.5.18",
@@ -12243,6 +12621,7 @@
       "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/src/gql/graphql.ts
+++ b/src/gql/graphql.ts
@@ -666,6 +666,16 @@ export type LateCancellationRequiredError = Error & {
   code: Scalars['String'];
 };
 
+export type ApplePayConfig = {
+  __typename?: 'ApplePayConfig';
+  /** The ISO 4217 currency code (e.g. AED) */
+  currencyCode: Scalars['String'];
+  /** The ISO 3166-1 alpha-2 country code (e.g. AE) */
+  countryCode: Scalars['String'];
+  /** The display name shown on the Apple Pay sheet */
+  displayName: Scalars['String'];
+};
+
 export type LockShoppingCartResponse = {
   __typename?: 'LockShoppingCartResponse';
   isLocked: Scalars['Boolean'];
@@ -1384,6 +1394,8 @@ export type Query = {
   giftCards: Array<GiftCard>;
   /** Verifies whether an sms validation code is valid */
   isSMSValidationCodeValid?: Maybe<IsSmsValidationCodeValidUnion>;
+  /** Returns the Apple Pay configuration for a site */
+  applePayConfig: ApplePayConfig;
   /** Returns a single payment link by ID */
   paymentLink?: Maybe<PaymentLink>;
   /** Returns a list of payment links */
@@ -1501,6 +1513,11 @@ export type QueryCurrentUserWorkoutStatsPaginatedArgs = {
 
 export type QueryIsSmsValidationCodeValidArgs = {
   smsCode: Scalars['String'];
+};
+
+
+export type QueryApplePayConfigArgs = {
+  site: SiteEnum;
 };
 
 
@@ -2153,6 +2170,13 @@ export type GetRemainingCreditsQueryVariables = Exact<{ [key: string]: never; }>
 
 export type GetRemainingCreditsQuery = { __typename: 'Query', currentUser?: { __typename: 'User', remainingCredits: { __typename: 'ClientNotFoundInMindbody', code: string } | { __typename: 'RemainingCreditsSuccess', credits: number } } | null };
 
+export type GetApplePayConfigQueryVariables = Exact<{
+  site: SiteEnum;
+}>;
+
+
+export type GetApplePayConfigQuery = { __typename: 'Query', applePayConfig: { __typename: 'ApplePayConfig', currencyCode: string, countryCode: string, displayName: string } };
+
 export type GetShoppingCartQueryVariables = Exact<{
   site: SiteEnum;
 }>;
@@ -2504,6 +2528,7 @@ export const GeneratePayfortFormDocument = {"kind":"Document","definitions":[{"k
 export const GetCartSummaryDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetCartSummary"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"site"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"SiteEnum"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"currentUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"shoppingCart"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"site"},"value":{"kind":"Variable","name":{"kind":"Name","value":"site"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"items"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"quantity"}},{"kind":"Field","name":{"kind":"Name","value":"variant"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}}]}}]}}]}}]}}]}}]} as unknown as DocumentNode<GetCartSummaryQuery, GetCartSummaryQueryVariables>;
 export const GetProductsDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetProducts"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"site"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"SiteEnum"}}}},{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"input"}},"type":{"kind":"NamedType","name":{"kind":"Name","value":"ProductsInput"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"products"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"site"},"value":{"kind":"Variable","name":{"kind":"Name","value":"site"}}},{"kind":"Argument","name":{"kind":"Name","value":"input"},"value":{"kind":"Variable","name":{"kind":"Name","value":"input"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ProductFields"}}]}}]}},...ProductFieldsFragmentDoc.definitions]} as unknown as DocumentNode<GetProductsQuery, GetProductsQueryVariables>;
 export const GetRemainingCreditsDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetRemainingCredits"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"currentUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"remainingCredits"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"RemainingCreditsSuccess"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"credits"}}]}},{"kind":"InlineFragment","typeCondition":{"kind":"NamedType","name":{"kind":"Name","value":"ClientNotFoundInMindbody"}},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"code"}}]}}]}}]}}]}}]} as unknown as DocumentNode<GetRemainingCreditsQuery, GetRemainingCreditsQueryVariables>;
+export const GetApplePayConfigDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetApplePayConfig"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"site"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"SiteEnum"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"applePayConfig"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"site"},"value":{"kind":"Variable","name":{"kind":"Name","value":"site"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"currencyCode"}},{"kind":"Field","name":{"kind":"Name","value":"countryCode"}},{"kind":"Field","name":{"kind":"Name","value":"displayName"}}]}}]}}]} as unknown as DocumentNode<GetApplePayConfigQuery, GetApplePayConfigQueryVariables>;
 export const GetShoppingCartDocument = {"kind":"Document", "definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"GetShoppingCart"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"site"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"SiteEnum"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"currentUser"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"shoppingCart"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"site"},"value":{"kind":"Variable","name":{"kind":"Name","value":"site"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"FragmentSpread","name":{"kind":"Name","value":"ShoppingCartFields"}}]}}]}}]}},...ShoppingCartFieldsFragmentDoc.definitions]} as unknown as DocumentNode<GetShoppingCartQuery, GetShoppingCartQueryVariables>;
 export const NewLockShoppingCartDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"mutation","name":{"kind":"Name","value":"NewLockShoppingCart"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"site"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"SiteEnum"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"newLockShoppingCart"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"site"},"value":{"kind":"Variable","name":{"kind":"Name","value":"site"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"isLocked"}},{"kind":"Field","name":{"kind":"Name","value":"merchantReference"}}]}}]}}]} as unknown as DocumentNode<NewLockShoppingCartMutation, NewLockShoppingCartMutationVariables>;
 export const PaymentLinkDocument = {"kind":"Document","definitions":[{"kind":"OperationDefinition","operation":"query","name":{"kind":"Name","value":"PaymentLink"},"variableDefinitions":[{"kind":"VariableDefinition","variable":{"kind":"Variable","name":{"kind":"Name","value":"id"}},"type":{"kind":"NonNullType","type":{"kind":"NamedType","name":{"kind":"Name","value":"ID"}}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"paymentLink"},"arguments":[{"kind":"Argument","name":{"kind":"Name","value":"id"},"value":{"kind":"Variable","name":{"kind":"Name","value":"id"}}}],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"id"}},{"kind":"Field","name":{"kind":"Name","value":"title"}},{"kind":"Field","name":{"kind":"Name","value":"amount"}},{"kind":"Field","name":{"kind":"Name","value":"currency"}},{"kind":"Field","name":{"kind":"Name","value":"url"}},{"kind":"Field","name":{"kind":"Name","value":"notificationEmailAddress"}},{"kind":"Field","name":{"kind":"Name","value":"site"},"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"name"}},{"kind":"Field","name":{"kind":"Name","value":"code"}}]}}]}}]}}]} as unknown as DocumentNode<PaymentLinkQuery, PaymentLinkQueryVariables>;

--- a/src/modules/shop/composables/useApplePay.ts
+++ b/src/modules/shop/composables/useApplePay.ts
@@ -1,0 +1,189 @@
+import { computed, ref } from 'vue'
+import { useShopApiService } from '@/modules/shop/composables/useShopApiService'
+import { appStore } from '@/stores/appStorage'
+import { useAuthenticationStore } from '@/stores/authToken'
+
+type ApplePayConfigData = {
+  currencyCode: string
+  countryCode: string
+  displayName: string
+}
+
+export const useApplePay = () => {
+  const shopApi = useShopApiService()
+  const paymentsBaseUrl = import.meta.env.VITE_CRANK_PAYMENTS_URL as string
+
+  const config = ref<ApplePayConfigData | null>(null)
+  const isProcessing = ref(false)
+  const error = ref<string | null>(null)
+
+  const isApplePayAvailable = computed(() => {
+    return !!window.ApplePaySession && window.self === window.top
+  })
+
+  async function fetchApplePayConfig(): Promise<void> {
+    try {
+      config.value = await shopApi.getApplePayConfig(appStore().site)
+    } catch (e) {
+      console.error('Failed to fetch Apple Pay config:', e)
+      config.value = null
+    }
+  }
+
+  async function startApplePayPayment(
+    merchantReference: string,
+    amount: number,
+    itemDescription: string
+  ): Promise<boolean> {
+    if (!config.value) {
+      throw new Error('Apple Pay configuration not loaded.')
+    }
+
+    isProcessing.value = true
+    error.value = null
+
+    const applePayConfig = config.value
+    const authStore = useAuthenticationStore()
+
+    return new Promise<boolean>((resolve) => {
+      const paymentRequest: ApplePayPaymentRequest = {
+        currencyCode: applePayConfig.currencyCode,
+        countryCode: applePayConfig.countryCode,
+        lineItems: [{ label: itemDescription, amount }],
+        total: {
+          label: applePayConfig.displayName,
+          amount
+        },
+        supportedNetworks: ['amex', 'masterCard', 'visa'],
+        merchantCapabilities: ['supports3DS']
+      }
+
+      const session = new ApplePaySession(1, paymentRequest)
+
+      let paymentProcessStarted = false
+
+      session.onvalidatemerchant = async (event) => {
+        try {
+          const response = await fetch(
+            `${paymentsBaseUrl}/apple-pay/verify-merchant?u=${encodeURIComponent(event.validationURL)}`,
+            {
+              headers: {
+                Authorization: `Bearer ${authStore.token}`
+              }
+            }
+          )
+          const merchantSession = await response.json()
+          session.completeMerchantValidation(merchantSession)
+        } catch (e) {
+          console.error('Merchant validation failed:', e)
+          error.value = 'Merchant validation failed.'
+          session.completePayment(ApplePaySession.STATUS_FAILURE)
+          isProcessing.value = false
+          resolve(false)
+        }
+      }
+
+      session.onshippingcontactselected = () => {
+        const newTotal: ApplePayLineItem = {
+          type: 'final',
+          label: applePayConfig.displayName,
+          amount
+        }
+        const newLineItems: ApplePayLineItem[] = [
+          { type: 'final', label: itemDescription, amount }
+        ]
+        session.completeShippingContactSelection(
+          ApplePaySession.STATUS_SUCCESS,
+          '',
+          newTotal,
+          newLineItems
+        )
+      }
+
+      session.onshippingmethodselected = () => {
+        const newTotal: ApplePayLineItem = {
+          type: 'final',
+          label: applePayConfig.displayName,
+          amount
+        }
+        const newLineItems: ApplePayLineItem[] = [
+          { type: 'final', label: itemDescription, amount }
+        ]
+        session.completeShippingMethodSelection(
+          ApplePaySession.STATUS_SUCCESS,
+          newTotal,
+          newLineItems
+        )
+      }
+
+      session.onpaymentmethodselected = () => {
+        const newTotal: ApplePayLineItem = {
+          type: 'final',
+          label: applePayConfig.displayName,
+          amount
+        }
+        const newLineItems: ApplePayLineItem[] = [
+          { type: 'final', label: itemDescription, amount }
+        ]
+        session.completePaymentMethodSelection(newTotal, newLineItems)
+      }
+
+      session.onpaymentauthorized = async (event) => {
+        paymentProcessStarted = true
+        try {
+          const response = await fetch(
+            `${paymentsBaseUrl}/payfort/apple-pay-process-purchase`,
+            {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${authStore.token}`
+              },
+              body: JSON.stringify({
+                applePayment: event.payment.token,
+                merchantReference
+              })
+            }
+          )
+
+          const data = await response.json()
+
+          if (response.ok) {
+            session.completePayment(ApplePaySession.STATUS_SUCCESS)
+            isProcessing.value = false
+            resolve(true)
+          } else {
+            console.error('Payment processing failed:', data)
+            session.completePayment(ApplePaySession.STATUS_FAILURE)
+            error.value = 'Payment processing failed.'
+            isProcessing.value = false
+            resolve(false)
+          }
+        } catch (e) {
+          console.error('Error sending payment token:', e)
+          session.completePayment(ApplePaySession.STATUS_FAILURE)
+          error.value = 'An error occurred while processing the payment.'
+          isProcessing.value = false
+          resolve(false)
+        }
+      }
+
+      session.oncancel = () => {
+        if (!paymentProcessStarted) {
+          isProcessing.value = false
+          resolve(false)
+        }
+      }
+
+      session.begin()
+    })
+  }
+
+  return {
+    isApplePayAvailable,
+    fetchApplePayConfig,
+    startApplePayPayment,
+    isProcessing,
+    error
+  }
+}

--- a/src/modules/shop/graphql/GetApplePayConfig.query.graphql
+++ b/src/modules/shop/graphql/GetApplePayConfig.query.graphql
@@ -1,0 +1,7 @@
+query GetApplePayConfig($site: SiteEnum!) {
+  applePayConfig(site: $site) {
+    currencyCode
+    countryCode
+    displayName
+  }
+}

--- a/src/modules/shop/models/ShoppingCartModel.ts
+++ b/src/modules/shop/models/ShoppingCartModel.ts
@@ -81,6 +81,10 @@ export class ShoppingCartModel {
    * Returns the calculated subtotal as a formatted string.
    * @returns A string representing the formatted price.
    */
+  public get amountToPay(): number {
+    return this.totals?.amountToPay ?? 0
+  }
+
   public get formattedSubtotal(): string {
     return formatPrice(this.totals?.subTotal, this.currency)
   }

--- a/src/modules/shop/services/IShopApiService.ts
+++ b/src/modules/shop/services/IShopApiService.ts
@@ -181,4 +181,15 @@ export interface IShopApiService {
    * @return A promise that resolves to the number of remaining credits.   *
    * */
   getRemainingCredits(): Promise<number>
+
+  /**
+   * Fetches the Apple Pay configuration for a given site.
+   * @param site The site to fetch the config for.
+   * @returns A promise that resolves with the Apple Pay config.
+   */
+  getApplePayConfig(site: SiteEnum): Promise<{
+    currencyCode: string
+    countryCode: string
+    displayName: string
+  }>
 }

--- a/src/modules/shop/services/ShopApiService.ts
+++ b/src/modules/shop/services/ShopApiService.ts
@@ -18,6 +18,9 @@ import {
   EmptyShoppingCartDocument,
   type EmptyShoppingCartMutation,
   type EmptyShoppingCartMutationVariables,
+  GetApplePayConfigDocument,
+  type GetApplePayConfigQuery,
+  type GetApplePayConfigQueryVariables,
   GeneratePayfortFormDocument,
   type GeneratePayfortFormMutation,
   type GeneratePayfortFormMutationVariables,
@@ -706,6 +709,41 @@ export class ShopApiService implements IShopApiService {
     } catch (error) {
       console.error('ApiService: Error fetching shopping cart:', error)
       throw new Error('Failed to fetch shopping cart.')
+    }
+  }
+
+  async getApplePayConfig(
+    site: SiteEnum
+  ): Promise<{ currencyCode: string; countryCode: string; displayName: string }> {
+    try {
+      const { data, errors } = await this.authApiClient.query<
+        GetApplePayConfigQuery,
+        GetApplePayConfigQueryVariables
+      >({
+        query: GetApplePayConfigDocument,
+        variables: { site },
+        fetchPolicy: 'network-only'
+      })
+
+      if (errors && errors.length > 0) {
+        throw new ApiError(
+          `GraphQL error fetching Apple Pay config: ${errors.map((e) => e.message).join(', ')}`
+        )
+      }
+
+      const config = data?.applePayConfig
+      if (!config) {
+        throw new Error('Did not receive Apple Pay configuration from the server.')
+      }
+
+      return {
+        currencyCode: config.currencyCode,
+        countryCode: config.countryCode,
+        displayName: config.displayName
+      }
+    } catch (error) {
+      console.error('ApiService.getApplePayConfig failed:', error)
+      throw error
     }
   }
 }

--- a/src/modules/shop/types/apple-pay.d.ts
+++ b/src/modules/shop/types/apple-pay.d.ts
@@ -1,0 +1,73 @@
+/**
+ * @file Global type declarations for the Apple Pay JS API.
+ *
+ * These declarations provide TypeScript awareness of the ApplePaySession class
+ * available in Safari browsers for processing Apple Pay payments.
+ */
+
+export {}
+
+declare global {
+  interface Window {
+    ApplePaySession?: typeof ApplePaySession
+  }
+
+  interface ApplePayLineItem {
+    label: string
+    amount: number
+    type?: 'final' | 'pending'
+  }
+
+  interface ApplePayPaymentRequest {
+    currencyCode: string
+    countryCode: string
+    lineItems?: ApplePayLineItem[]
+    total: ApplePayLineItem
+    supportedNetworks: string[]
+    merchantCapabilities: string[]
+  }
+
+  interface ApplePayValidateMerchantEvent {
+    validationURL: string
+  }
+
+  interface ApplePayPaymentAuthorizedEvent {
+    payment: {
+      token: unknown
+      shippingContact?: unknown
+    }
+  }
+
+  class ApplePaySession {
+    static readonly STATUS_SUCCESS: number
+    static readonly STATUS_FAILURE: number
+
+    constructor(version: number, paymentRequest: ApplePayPaymentRequest)
+
+    begin(): void
+    completeMerchantValidation(merchantSession: unknown): void
+    completeShippingContactSelection(
+      status: number,
+      newShippingMethods: unknown,
+      newTotal: ApplePayLineItem,
+      newLineItems: ApplePayLineItem[]
+    ): void
+    completeShippingMethodSelection(
+      status: number,
+      newTotal: ApplePayLineItem,
+      newLineItems: ApplePayLineItem[]
+    ): void
+    completePaymentMethodSelection(
+      newTotal: ApplePayLineItem,
+      newLineItems: ApplePayLineItem[]
+    ): void
+    completePayment(status: number): void
+
+    onvalidatemerchant: ((event: ApplePayValidateMerchantEvent) => void) | null
+    onshippingcontactselected: ((event: unknown) => void) | null
+    onshippingmethodselected: ((event: unknown) => void) | null
+    onpaymentmethodselected: ((event: unknown) => void) | null
+    onpaymentauthorized: ((event: ApplePayPaymentAuthorizedEvent) => void) | null
+    oncancel: ((event: unknown) => void) | null
+  }
+}

--- a/src/modules/shop/views/CheckoutView.vue
+++ b/src/modules/shop/views/CheckoutView.vue
@@ -7,7 +7,7 @@
 
 // Libs & Frameworks
 import { computed, inject, onMounted, reactive, ref } from 'vue'
-import { useRoute } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 
 // Vuelidate Validators
 import useVuelidate from '@vuelidate/core'
@@ -23,6 +23,7 @@ import GiftCardForm from '@/modules/shop/components/GiftCardForm.vue'
 
 // Composables, Services & Utilities
 import { useCheckout } from '@/modules/shop/composables/useCheckout'
+import { useApplePay } from '@/modules/shop/composables/useApplePay'
 import { useAuth } from '@/modules/auth/composables/useAuth'
 import { useShoppingCart } from '@/modules/shop/composables/useShoppingCart'
 import { createPayfortFormManager } from '@/modules/shop/services/PayfortFormManager'
@@ -40,6 +41,7 @@ import applePay from '../assets/images/apple_pay_button_pay.png'
 import { appStore } from '@/stores/appStorage'
 import { SiteEnum } from '@/modules/shared/interfaces/site.enum'
 import { useFlutterBridge } from '@/modules/shop/composables/useFlutterBridge'
+import { useShopApiService } from '@/modules/shop/composables/useShopApiService'
 
 //
 // -----------------
@@ -49,10 +51,13 @@ import { useFlutterBridge } from '@/modules/shop/composables/useFlutterBridge'
 
 const apiService = inject<IApiService>('gqlApiService')!
 const { error: checkoutError, payfortFormHtml, initiatePayment } = useCheckout()
+const { isApplePayAvailable, fetchApplePayConfig, startApplePayPayment } = useApplePay()
 const { detailedCart, fetchCartDetails, isLoading, itemsText } = useShoppingCart()
 const { user, isAuthenticated, isLoading: isAuthLoading, fetchCurrentUser } = useAuth(apiService)
 const { isInWebview, webviewToken, sendFailure } = useFlutterBridge()
+const shopApi = useShopApiService()
 const route = useRoute()
+const router = useRouter()
 
 //
 // -----------------
@@ -266,7 +271,26 @@ const handleSubmit = async () => {
 
     window.scrollTo({ top: 0, behavior: 'smooth' })
   } else if (selectedPaymentMethod.value === 'digitalWallet') {
-    showErrorModal('Not Implemented', 'Digital wallet not supported yet.')
+    isSubmitting.value = true
+    try {
+      const { isLocked, merchantReference } = await shopApi.lockShoppingCart(appStore().site)
+      if (!isLocked) {
+        throw new Error('Could not secure the shopping cart for payment. Please try again.')
+      }
+
+      const amount = detailedCart.value?.amountToPay ?? 0
+      const description = itemsText.value || 'Purchase'
+      const success = await startApplePayPayment(merchantReference, amount, description)
+
+      if (success) {
+        router.push({ name: 'after-checkout', query: { merchantReference } })
+      }
+    } catch (e: any) {
+      if (isInWebview.value) sendFailure()
+      showErrorModal('Payment Error', e?.message || 'An unexpected error occurred.')
+    } finally {
+      isSubmitting.value = false
+    }
   }
 }
 
@@ -419,6 +443,7 @@ onMounted(() => {
 
   fetchCurrentUser()
   fetchCartDetails()
+  fetchApplePayConfig()
 })
 
 //
@@ -621,19 +646,21 @@ const onFingerprintError = (error: Error) => {
                   </div>
                 </div>
 
-                <!-- Digital Wallet Payment Option -->
-                <p class="section-title mt-4">PAY WITH YOUR DIGITAL WALLET</p>
-                <div class="digital-wallet-container">
-                  <input
-                    type="radio"
-                    id="digitalWallet"
-                    value="digitalWallet"
-                    name="paymentMethod"
-                    v-model="selectedPaymentMethod"
-                  />
-                  <label for="digitalWallet">PAY WITH</label>
-                  <img :src="applePay" alt="Apple Pay" class="apple-pay-logo" />
-                </div>
+                <!-- Digital Wallet Payment Option (Safari only) -->
+                <template v-if="isApplePayAvailable">
+                  <p class="section-title mt-4">PAY WITH YOUR DIGITAL WALLET</p>
+                  <div class="digital-wallet-container">
+                    <input
+                      type="radio"
+                      id="digitalWallet"
+                      value="digitalWallet"
+                      name="paymentMethod"
+                      v-model="selectedPaymentMethod"
+                    />
+                    <label for="digitalWallet">PAY WITH</label>
+                    <img :src="applePay" alt="Apple Pay" class="apple-pay-logo" />
+                  </div>
+                </template>
 
                 <section class="payment-footer">
                   <button


### PR DESCRIPTION
Summary

- Add Apple Pay as a payment option in the checkout flow, migrating the functionality from the legacy crank-payments JS
  implementation
- Apple Pay section (radio button + logo) is only visible in Safari browsers (checks window.ApplePaySession and not in
  iframe)
- When selected, locks the shopping cart, launches the native Apple Pay sheet, validates the merchant, and processes the
  payment token via existing REST endpoints (/apple-pay/verify-merchant, /payfort/apple-pay-process-purchase)
- Add ApplePayConfig GraphQL type and query to fetch per-site config (currencyCode, countryCode, displayName) from the
  backend

Files changed

- New: useApplePay.ts composable — Safari detection, config fetching, full ApplePaySession lifecycle
- New: apple-pay.d.ts — TypeScript declarations for Apple Pay JS API
- New: GetApplePayConfig.query.graphql — GraphQL query document
- Modified: ShopApiService / IShopApiService — added getApplePayConfig method
- Modified: ShoppingCartModel — added amountToPay numeric getter
- Modified: CheckoutView.vue — wired up composable, conditional rendering, payment flow
- Modified: graphql.ts — codegen output with new Apple Pay types

Test plan

- Open checkout in Chrome/Firefox — Apple Pay section should be hidden
- Open checkout in Safari — Apple Pay section should be visible
- Select Apple Pay radio, click PAY NOW — Apple Pay sheet should appear
- Complete payment in Apple Pay sheet — should redirect to after-checkout page
- Cancel Apple Pay sheet — should return to checkout with no errors
- Verify merchant validation and payment token are sent to the correct backend endpoints