### PR TITLE
feat: serve Apple Pay domain association file from env var at runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ coverage
 *.sln
 *.sw?
 dist
+
+# Apple Pay domain association (sensitive)
+public/.well-known/

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,9 @@ EXPOSE 80
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
   CMD wget --quiet --tries=1 --spider http://localhost/ || exit 1
 
-# Start nginx
-CMD ["nginx", "-g", "daemon off;"]
+# Copy entrypoint script
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+# Start nginx via entrypoint
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# Write Apple Pay domain association file from environment variable
+if [ -n "$APPLE_MERCHANT_ID_DOMAIN_ASSOCIATION" ]; then
+  mkdir -p /usr/share/nginx/html/.well-known
+  echo "$APPLE_MERCHANT_ID_DOMAIN_ASSOCIATION" > /usr/share/nginx/html/.well-known/apple-developer-merchantid-domain-association.txt
+fi
+
+# Start nginx
+exec nginx -g "daemon off;"

--- a/nginx.conf
+++ b/nginx.conf
@@ -44,6 +44,11 @@ http {
             add_header Cache-Control "public, immutable";
         }
 
+        # Serve .well-known files as plain text
+        location /.well-known/ {
+            default_type text/plain;
+        }
+
         # Vue Router support - redirect all requests to index.html
         location / {
             try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Adds a Docker entrypoint script that writes the merchant domain association file from the APPLE_MERCHANT_ID_DOMAIN_ASSOCIATION environment variable, keeping the sensitive file out of version control.